### PR TITLE
reduce cycles before fsync

### DIFF
--- a/api/routes/drives.ts
+++ b/api/routes/drives.ts
@@ -128,7 +128,7 @@ router.post('/fio', async (req: Request, res: Response) => {
     `--io_size=${io_size || "10g"}`,
     `--ioengine=${ioengine || "libaio"}`,
     `--iodepth=${iodepth || 32}`,
-    `--fsync=${fsync || 10000}`,
+    `--fsync=${fsync || 64}`,
     `--invalidate=${invalidate || 0}`,
     `--overwrite=${overwrite || 0}`,
     '--group_reporting',


### PR DESCRIPTION
fsync flushes the changes to the disk, so if we give it a lower number, it should give a closer speed to the actual underlying disk writes